### PR TITLE
Typo in turtlebot3_manipulation_gazebo.launch

### DIFF
--- a/turtlebot3_manipulation_gazebo/launch/turtlebot3_manipulation_gazebo.launch
+++ b/turtlebot3_manipulation_gazebo/launch/turtlebot3_manipulation_gazebo.launch
@@ -26,6 +26,6 @@
   <include file="$(find turtlebot3_manipulation_gazebo)/launch/controller_utils.launch"/>
 
   <!-- run controllers -->
-  <include file="$(find turtlebot3_manipulation_gazebo)/launch/turtlebot3_manipulation_controller.launch/">
+  <include file="$(find turtlebot3_manipulation_gazebo)/launch/turtlebot3_manipulation_controller.launch"/>
 
 </launch>


### PR DESCRIPTION
Resolves RLException: Invalid roslaunch XML syntax: mismatched tag: line 31, column 2